### PR TITLE
Update email templates

### DIFF
--- a/email/archive_notice.txt
+++ b/email/archive_notice.txt
@@ -17,9 +17,9 @@ Since we've released #.#.#, it is time to archive #.#.#-1.
 
 Archiving this release means that we no longer support it, and we will remove any references to it from our website and our wiki. However, the original files will still be available to anyone browsing the release archives at:
 
-    http://archive.apache.org/dist/couchdb/
+    https://archive.apache.org/dist/couchdb/
 
-    http://wiki.apache.org/couchdb/CurrentReleases#Archived_Releases
+    https://cwiki.apache.org/confluence/display/COUCHDB/Current+Releases#CurrentReleases-ArchivedReleases
 
 You do not need to respond if you are in agreement. If there is no response in 72 hours, I will assume lazy consensus. If we reach consensus, I archive the release.
 

--- a/email/committer_1_vote.txt
+++ b/email/committer_1_vote.txt
@@ -13,7 +13,7 @@ A successful election would signify that the PMC trusts this person to be loyal 
 
 Required reading:
 
-    http://couchdb.apache.org/bylaws.html#committers
+    https://couchdb.apache.org/bylaws.html#committers
 
 Per the bylaws, this vote uses the lazy majority approval model, meaning that three binding +1 votes and more binding +1 votes than -1 votes are needed.
 

--- a/email/committer_2_result.txt
+++ b/email/committer_2_result.txt
@@ -3,7 +3,7 @@ To: private@couchdb.apache.org
 Subject: [RESULT] (Was: Re: [VOTE] (Was: Re: [DISCUSS] Elect %NAME% as committer))
 ================================================================================
 
-Dear PMC, 
+Dear PMC,
 
 The vote has now closed.
 

--- a/email/committer_3_invite.txt
+++ b/email/committer_3_invite.txt
@@ -12,11 +12,11 @@ We value your contributions to date, and believe that you are committed to the p
 
 You can read more about the role in our bylaws:
 
-    http://couchdb.apache.org/bylaws.html#committers
+    https://couchdb.apache.org/bylaws.html#committers
 
 Please also familiarise yourself with our code of conduct:
 
-    http://couchdb.apache.org/conduct.html
+    https://couchdb.apache.org/conduct.html
 
 While these documents apply to all community members, by accepting this invitation you are indicating that you have read and agree to them.
 
@@ -26,22 +26,22 @@ Of course, you can decline and continue to contribute as you do now. If you do d
 
 Either way, please let us know in reply to the private@couchdb.apache.org list only. If you accept, we will announce your new position on the dev@couchdb.apache.org list after your account is created.
 
-[CHECK http://people.apache.org/committer-index.html - IF PRESENT, USE THIS PARAGRAPH]
+[CHECK https://people.apache.org/committer-index.html - IF PRESENT, USE THIS PARAGRAPH]
 If you accept, since you already have an Apache id, the PMC will grant you write access to the repository.
 
-[CHECK http://people.apache.org/unlistedclas.html - IF PRESENT, USE THIS PARAGRAPH]
-If you accept, since you already have an iCLA on file, the PMC will request an Apache id for you. In your response, please choose an id that is not already in use. See http://people.apache.org/committer-index.html
+[CHECK https://whimsy.apache.org/officers/unlistedclas.cgi - IF PRESENT, USE THIS PARAGRAPH]
+If you accept, since you already have an ICLA on file, the PMC will request an Apache id for you. In your response, please choose an id that is not already in use. See https://people.apache.org/committer-index.html
 ]
 
 [OTHERWISE, USE THIS SECTION]
-If you accept, the next step is to register an iCLA:
+If you accept, the next step is to register an ICLA:
 
-  1. Details of the iCLA and the forms are found here: http://www.apache.org/licenses/#clas
+  1. Details of the ICLA and the forms are found here: https://www.apache.org/licenses/contributor-agreements.html#clas
 
-  2. Instructions for its completion and return to the Secretary of the ASF are found at http://www.apache.org/licenses/#submitting . Do not submit ICLAs to anyone but secretary, but please do cc: [private@couchdb.apache.org]
+  2. Instructions for its completion and return to the Secretary of the ASF are found at https://www.apache.org/licenses/contributor-agreements.html#submitting . Do not submit ICLAs to anyone but the Secretary.
 
-  3. When you transmit the completed iCLA, request to notify Apache CouchDB and choose a unique Apache id. Look to see if your preferred id is already taken at http://people.apache.org/committer-index.html . This will allow the Secretary to notify the PMC when your iCLA has been recorded.
+  3. When you transmit the completed ICLA, request to notify Apache CouchDB and choose a unique Apache id. Look to see if your preferred id is already taken at https://people.apache.org/committer-index.html . This will allow the Secretary to notify the PMC when your ICLA has been recorded.
 
-  4. Be sure to reply to this email and let us know you've completed your iCLA.
+  4. Be sure to reply to this email and let us know you've completed your ICLA.
 
 On behalf of the CouchDB PMC,

--- a/email/committer_4_accept.txt
+++ b/email/committer_4_accept.txt
@@ -15,11 +15,11 @@ You will receive a few emails from various different people as this process move
 In response to this email, please indicate:
 
  * Your IRC nick (if you have one)
- * Your Twitter account (if you have one)
+ * Your Slack nick (if you have one)
 
 Please work your way through:
 
-    http://s.apache.org/couchdb-committer-first-steps
+    https://s.apache.org/couchdb-committer-first-steps
 
 This document contains:
 

--- a/email/committer_5_done.txt
+++ b/email/committer_5_done.txt
@@ -12,16 +12,15 @@ You now have write access to certain parts of the ASF.
 
 Don't forget to work your way through the steps here:
 
-    http://s.apache.org/couchdb-committer-first-steps
+    https://s.apache.org/couchdb-committer-first-steps
 
-While all of the items are important, we want to remind you of three specific
-ones that are key.
+While all of the items are important, we want to remind you of three specific ones that are key.
 
 We abide by a code of conduct and a set of bylaws. You should familiarise yourself with both documents. As a committer, people will look to you for cues about how to act. Please help us set the right standard.
 
-    http://couchdb.apache.org/conduct.html
+    https://couchdb.apache.org/conduct.html
 
-    http://couchdb.apache.org/bylaws.html
+    https://couchdb.apache.org/bylaws.html
 
 You will want to complete the Git / GitHub / ASF integration step for the best experience when committing to our repositories:
 

--- a/email/pmc_2_result.txt
+++ b/email/pmc_2_result.txt
@@ -3,7 +3,7 @@ To: private@couchdb.apache.org
 Subject: [RESULT] (Was: Re: [VOTE] (Was: Re: [DISCUSS] Elect %NAME% as PMC member))
 ================================================================================
 
-Dear PMC, 
+Dear PMC,
 
 The vote has now closed.
 

--- a/email/release_1_notice.txt
+++ b/email/release_1_notice.txt
@@ -19,7 +19,7 @@ The current release note draft is here:
 
     https://docs.couchdb.org/en/latest/whatsnew/#.#.html
 
-Please read this through and suggest any changes via PR against the apache/couchdb-documentation repository. The information was taken from the GitHub issue tracker and PR notes, and aims to be descriptive and useful to the average CouchDB user.
+Please read this through and suggest any changes via PR against the apache/couchdb repository, under src/docs. The information was taken from the GitHub issue tracker and PR notes, and aims to be descriptive and useful to the average CouchDB user.
 
 I will send out a follow-up reminder, with progress report, in one week.
 

--- a/email/release_6_promote.txt
+++ b/email/release_6_promote.txt
@@ -25,8 +25,6 @@ And don't forget the rest:
 
 %LOBSTERS_URL%
 
-%GOOGLE_PLUS_URLS%
-
 %FACEBOOK_URL%
 
 Please take a moment to like/upvote these links and share them with your friends. Any help you can provide is here very valuable.

--- a/email/translator_2_confirm.txt
+++ b/email/translator_2_confirm.txt
@@ -28,7 +28,7 @@ After you have set a password, please login here:
 
 You are now ready to start with translating. To make the start a bit easier for you, we have created a Wiki page, where you can find useful information regarding your translation work:
 
-	https://wiki.apache.org/couchdb/Translation
+	https://cwiki.apache.org/confluence/display/COUCHDB/Translation+Guide
 
 If you have any questions, please don't wait to ask on the l10n@couchdb.apache.org mailing-list.
 


### PR DESCRIPTION
- Remove obsolete information (references to Twitter, Google+).
- Update links, replace HTTP with HTTPS.
- In the committer invitation, remove the phrase about CCing the PMC with the ICLA.  It is contradicted later and that is not how the ASF Secretary asks to do it.
- Update reference about apache/couchdb-documentation.
- Fix letter casing, remove trailing whitespaces.